### PR TITLE
Removed dependency for templating.globals.

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,7 +21,6 @@ services:
             - "@templating.name_parser"
             - "@templating.locator"
             - "@intaro_pinba.stopwatch"
-            - "@templating.globals"
 
     doctrine.dbal.logger:
         class: %intaro_pinba.dbal.logger.class%

--- a/Twig/TimedTwigEngine.php
+++ b/Twig/TimedTwigEngine.php
@@ -12,7 +12,6 @@
 namespace Intaro\PinbaBundle\Twig;
 
 use Symfony\Bundle\TwigBundle\TwigEngine;
-use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Component\Templating\TemplateNameParserInterface;
 use Intaro\PinbaBundle\Stopwatch\Stopwatch;
 use Symfony\Component\Config\FileLocatorInterface;
@@ -32,11 +31,10 @@ class TimedTwigEngine extends TwigEngine
      * @param TemplateNameParserInterface $parser      A TemplateNameParserInterface instance
      * @param FileLocatorInterface        $locator     A FileLocatorInterface instance
      * @param Stopwatch                   $stopwatch   A Stopwatch instance
-     * @param GlobalVariables             $globals     A GlobalVariables instance
      */
-    public function __construct(\Twig_Environment $environment, TemplateNameParserInterface $parser, FileLocatorInterface $locator, Stopwatch $stopwatch, GlobalVariables $globals = null)
+    public function __construct(\Twig_Environment $environment, TemplateNameParserInterface $parser, FileLocatorInterface $locator, Stopwatch $stopwatch)
     {
-        parent::__construct($environment, $parser, $locator, $globals);
+        parent::__construct($environment, $parser, $locator);
 
         $this->stopwatch = $stopwatch;
     }


### PR DESCRIPTION
В symfony 2.7 из-за этой зависимости падает на prod.
Обсуждение: https://github.com/symfony/symfony/issues/14719